### PR TITLE
Add controllable automated derived values on set

### DIFF
--- a/src/routes/zustand/components/StatsItem.jsx
+++ b/src/routes/zustand/components/StatsItem.jsx
@@ -1,12 +1,15 @@
 import React from 'react'
+import { useTasksStore } from '../tasks-store'
 
-const StatsItem = ({ label, value }) => {
+const StatsItem = ({ label, statKey, formatter }) => {
   console.log(`StatsItem ${label} rendered`)
-  
+
+  const value = useTasksStore((state) => state[statKey])
+
   return (
     <div className="stat-item">
       <span className="stat-label">{label}:</span>
-      <span className="stat-value">{value}</span>
+      <span className="stat-value">{formatter ? formatter(value) : value}</span>
     </div>
   )
 }

--- a/src/routes/zustand/components/TaskList.jsx
+++ b/src/routes/zustand/components/TaskList.jsx
@@ -1,32 +1,23 @@
 import React from 'react'
-import { useShallow } from 'zustand/react/shallow'
 import SearchForm from './SearchForm'
 import TaskItem from './TaskItem'
 import { useTasksStore } from '../tasks-store'
 
 const TaskList = () => {
   const searchQuery = useTasksStore(state => state.searchQuery)
-  const filteredIds = useTasksStore(
-    useShallow((state) => {
-      const q = searchQuery.toLowerCase()
-      return state.tasks.reduce((acc, task) => {
-        if (task.title.toLowerCase().includes(q)) acc.push(task.id)
-        return acc
-      }, [])
-    })
-  )
+  const displayTaskIds = useTasksStore(state => state.displayTaskIds)
 
   return (
     <div className="task-list">
       <SearchForm />
       <div className="tasks">
 
-        {filteredIds.length === 0 ? (
+        {displayTaskIds.length === 0 ? (
           <div className="no-tasks">
             {searchQuery ? 'No tasks match your search' : 'No tasks yet'}
           </div>
         ) : (
-          filteredIds.map(id => (
+          displayTaskIds.map(id => (
             <TaskItem key={id} taskId={id} />
           ))
         )}

--- a/src/routes/zustand/components/TaskStats.jsx
+++ b/src/routes/zustand/components/TaskStats.jsx
@@ -1,28 +1,29 @@
 import React from 'react'
-import { useTasks } from '../tasks-store'
 import StatsItem from './StatsItem'
+import { useTasksStore } from '../tasks-store'
 
-const TaskStats = () => {
-  const tasks = useTasks()
-  
-  console.log('TaskStats rendered')
+const TaskStats = () => {  
+  // console.log('TaskStats rendered')
 
-  const completed = tasks.filter(t => t.completed).length;
+  const useRelativeStats = useTasksStore(state => state.useRelativeStats)
+  const setUseRelativeStats = useTasksStore(state => state.setUseRelativeStats)
+  const handleUseRelativeStatsChange = (e) => {
+    setUseRelativeStats(e.target.checked)
+  }
+
   const stats = [
-    { label: 'Total Tasks', value: tasks.length },
-    { label: 'Completed', value: completed },
-    { label: 'Pending', value: tasks.length - completed },
-    { label: 'Completion Rate', value: tasks.length 
-      ? ((completed / tasks.length) * 100).toFixed(1) + '%'
-      : '0%'
-    }
+    { label: 'Total Tasks', key: 'totalTasks' },
+    { label: 'Completed', key: 'completedTasks' },
+    { label: 'Pending', key: 'pendingTasks' },
+    { label: 'Completion Rate',  key: 'completionRate', formatter: (value) => `${value.toFixed(1)}%` },
   ];
 
   return (
     <div className="task-stats">
       <h2>Statistics</h2>
+      <div>Display relative stats: <input type="checkbox" checked={useRelativeStats} onChange={handleUseRelativeStatsChange} /></div>
       {stats.map((stat) => (
-        <StatsItem key={stat.label} label={stat.label} value={stat.value} />
+        <StatsItem key={stat.label} label={stat.label} statKey={stat.key} value={stat.value} formatter={stat?.formatter} />
       ))}
     </div>
   )

--- a/src/routes/zustand/tasks-store.ts
+++ b/src/routes/zustand/tasks-store.ts
@@ -1,5 +1,5 @@
 import { create } from "zustand";
-import { persist, devtools } from "zustand/middleware";
+import { persist, devtools, createJSONStorage } from "zustand/middleware";
 import { useShallow } from "zustand/react/shallow";
 
 export type Task = {
@@ -9,61 +9,237 @@ export type Task = {
   createdAt: Date;
 };
 
+export type TaskStats = {
+  totalTasks: number;
+  completedTasks: number;
+  pendingTasks: number;
+  completionRate: number;
+};
+
 export type TasksState = {
   tasks: Task[];
+  displayTaskIds: number[];
+  totalTasks: number;
+  completedTasks: number;
+  pendingTasks: number;
+  completionRate: number;
   searchQuery: string;
+  useRelativeStats: boolean;
   addTask: (title: string) => void;
   toggleTask: (taskId: number) => void;
   deleteTask: (taskId: number) => void;
   setSearchQuery: (query: string) => void;
   getTaskById: (taskId: number) => Task | undefined;
+  setUseRelativeStats: (useRelativeStats: boolean) => void;
 };
+
+const calculateStatsWithContext = ({
+  tasks,
+  displayTaskIds,
+  useRelativeStats,
+}: Pick<TasksState, "tasks" | "displayTaskIds" | "useRelativeStats">): TaskStats => {
+  const selectedTaskList = useRelativeStats
+    ? tasks.filter((task) => displayTaskIds.includes(task.id))
+    : tasks;
+
+  const totalTasks = selectedTaskList.length;
+  const completedTasks = selectedTaskList.filter((task) => task.completed).length;
+  const pendingTasks = totalTasks - completedTasks;
+  const completionRate = totalTasks > 0 ? (completedTasks / totalTasks) * 100 : 0;
+
+  return { totalTasks, completedTasks, pendingTasks, completionRate };
+};
+
+type WrappedOptions = {
+  organizeDisplayIds?: boolean;
+  calculateStats?: boolean;
+};
+
+type OptionHandlers<StateType> = {
+  [OptionName in keyof WrappedOptions]-?: (nextState: StateType) => Partial<StateType>;
+};
+
+const runTruthyOptionHandlers = <StateType>(
+  providedOptions: WrappedOptions | undefined,
+  nextState: StateType,
+  handlers: OptionHandlers<StateType>
+): Partial<StateType> => {
+  const handlerEntries = Object.entries(handlers) as Array<
+    [keyof WrappedOptions, (state: StateType) => Partial<StateType>]
+  >;
+
+  const mergedPatch: Partial<StateType> = {};
+  for (const [optionName, handleOption] of handlerEntries) {
+    if (providedOptions?.[optionName]) {
+      Object.assign(mergedPatch, handleOption(nextState));
+    }
+  }
+  return mergedPatch;
+};
+
+type ExtendedSet = (
+  partialOrUpdater:
+    | TasksState
+    | Partial<TasksState>
+    | ((state: TasksState) => TasksState | Partial<TasksState>),
+  replaceWholeState?: boolean,
+  options?: WrappedOptions
+) => void;
 
 export const useTasksStore = create<TasksState>()(
   devtools(
     persist(
-    (set, get) => ({
-      tasks: [],
-      searchQuery: "",
-      addTask: (title: string) => {
-        set((state) => ({
-          tasks: [
-            ...state.tasks,
-            {
+      (originalSet, get) => {
+        const optionHandlers: OptionHandlers<TasksState> = {
+          organizeDisplayIds: (nextState) => {
+            const normalizedQuery = nextState.searchQuery.toLowerCase();
+            const matchingIds: number[] = [];
+            for (const task of nextState.tasks) {
+              if (task.title.toLowerCase().includes(normalizedQuery)) {
+                matchingIds.push(task.id);
+              }
+            }
+            originalSet({ displayTaskIds: matchingIds });
+            return { displayTaskIds: matchingIds };
+          },
+          calculateStats: (nextState) => {
+            const stats = calculateStatsWithContext(nextState)
+            originalSet({...stats})
+            return { ...stats }
+          },
+        };
+
+        const set: ExtendedSet = (partialOrUpdater, replaceWholeState, options) => {
+          const previousState = get();
+          const computedPatch =
+            typeof partialOrUpdater === "function"
+              ? (partialOrUpdater as (s: TasksState) => TasksState | Partial<TasksState>)(previousState)
+              : partialOrUpdater;
+
+          const fullNextState: TasksState = {
+            ...previousState,
+            ...(computedPatch as Partial<TasksState>),
+          };
+
+          const derivedPatch = runTruthyOptionHandlers(options, fullNextState, optionHandlers);
+
+          if (replaceWholeState === true) {
+            originalSet(
+              {
+                ...fullNextState,
+                ...derivedPatch,
+              } as TasksState,
+              true
+            );
+          } else {
+            originalSet({
+              ...(computedPatch as Partial<TasksState>),
+              ...derivedPatch,
+            });
+          }
+        };
+
+        return {
+          tasks: [],
+          displayTaskIds: [],
+          totalTasks: 0,
+          completedTasks: 0,
+          pendingTasks: 0,
+          completionRate: 0,
+          useRelativeStats: false,
+          searchQuery: "",
+
+          addTask: (title: string) => {
+            const newTask: Task = {
               id: Date.now(),
               title,
               completed: false,
               createdAt: new Date(),
-            },
-          ],
-        }));
+            };
+            set(
+              (state) => ({ tasks: [...state.tasks, newTask] }),
+              false,
+              { calculateStats: true, organizeDisplayIds: true }
+            );
+          },
+
+          toggleTask: (taskId: number) => {
+            set(
+              (state) => ({
+                tasks: state.tasks.map((task) =>
+                  task.id === taskId ? { ...task, completed: !task.completed } : task
+                ),
+              }),
+              false,
+              { calculateStats: true, organizeDisplayIds: true }
+            );
+          },
+
+          deleteTask: (taskId: number) => {
+            set(
+              (state) => ({ tasks: state.tasks.filter((task) => task.id !== taskId) }),
+              false,
+              { calculateStats: true, organizeDisplayIds: true }
+            );
+          },
+
+          getTaskById: (taskId: number) => get().tasks.find((task) => task.id === taskId),
+
+          setSearchQuery: (query: string) => {
+            set(
+              { searchQuery: query },
+              false,
+              { organizeDisplayIds: true, calculateStats: true }
+            );
+          },
+
+          setUseRelativeStats: (useRelativeStats: boolean) => {
+            set(
+              { useRelativeStats },
+              false,
+              { calculateStats: true }
+            );
+          },
+        };
       },
-      toggleTask: (taskId: number) => {
-        set((state) => ({
-          tasks: state.tasks.map((task) =>
-            task.id === taskId
-              ? { ...task, completed: !task.completed }
-              : task
-          ),
-        }));
-      },
-      deleteTask: (taskId: number) => {
-        set((state) => ({
-          tasks: state.tasks.filter((task) => task.id !== taskId),
-        }));
-      },
-      getTaskById: (taskId: number) => {
-        return get().tasks.find((task) => task.id === taskId);
-      },
-      setSearchQuery: (query: string) => set({ searchQuery: query }),
-    }),
-    {
-      name: "tasks-storage",
-      partialize: (state) => ({ tasks: state.tasks, searchQuery: state.searchQuery }),
-    }
-  ),
-  { name: "TasksStore", enabled: typeof window !== "undefined" }
-)
+      {
+        name: "tasks-storage",
+
+        // Only persist source-of-truth fields (no derived state)
+        partialize: (state) => ({
+          tasks: state.tasks,
+          searchQuery: state.searchQuery,
+          useRelativeStats: state.useRelativeStats,
+        }),
+
+        // Revive Dates from JSON
+        storage: createJSONStorage(() => localStorage, {
+          reviver: (key, value) => (key === "createdAt" && typeof value === "string" ? new Date(value) : value),
+        }),
+
+        merge: (persisted, current) => {
+          const merged = { ...current, ...(persisted as Partial<TasksState>) };
+
+          const normalizedQuery = merged.searchQuery?.toLowerCase?.() ?? "";
+          const displayTaskIds =
+            Array.isArray(merged.tasks)
+              ? merged.tasks
+                  .filter((task) => task.title.toLowerCase().includes(normalizedQuery))
+                  .map((task) => task.id)
+              : [];
+
+          const stats = calculateStatsWithContext(merged)
+
+          return {
+            ...merged,
+            displayTaskIds,
+            ...stats,
+          } as TasksState;
+        },
+      }
+    ),
+    { name: "TasksStore", enabled: typeof window !== "undefined" }
+  )
 );
 
 // Simple selectors


### PR DESCRIPTION
Update made to create a wrapped set function with options. This allows for coarse control over some derived data without the need to call it at each point. Instead you could use properties in an object to trigger a previously defined function

There is still one issue to look into concerning the relative stats, but for now this handles most of the approach